### PR TITLE
Revert "Add ospf"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,9 +11,6 @@ iptables_rules_in:
   - protocol: tcp
     dport: 22
 
-# opening ports for ospf
-iptables_rules_in_ospf: []
-
 # open ports forwarding
 iptables_rules_fwd: []
 #  - dst: 192.0.2.1

--- a/templates/ip6tables.j2
+++ b/templates/ip6tables.j2
@@ -62,10 +62,5 @@
 -A SERVICE_FWD -d {{ entry.dst }} -p {{ entry.protocol }} --sport {{ entry.sport | default("1024:65535") }} --dport {{ entry.dport }} -j ACCEPT
 {% endfor %}
 
-{% for entry in iptables_rules_in_ospf %}
-{% if entry.dst6 is defined %}
--A SERVICE_IN -d {{ entry.dst6 }} -p ospf -j ACCEPT
-{% endif %}
-{% endfor %}
 
 COMMIT

--- a/templates/iptables.j2
+++ b/templates/iptables.j2
@@ -62,10 +62,5 @@
 -A SERVICE_FWD -d {{ entry.dst }} -p {{ entry.protocol }} --sport {{ entry.sport | default("1024:65535") }} --dport {{ entry.dport }} -j ACCEPT
 {% endfor %}
 
-{% for entry in iptables_rules_in_ospf %}
-{% if entry.dst4 is defined %}
--A SERVICE_IN -d {{ entry.dst4 }} -p ospf -j ACCEPT
-{% endif %}
-{% endfor %}
 
 COMMIT


### PR DESCRIPTION
Reverts adfinis-sygroup/ansible-role-iptables#7

I don't see why we couldn't just use iptables_rules_in for OSPF? 

So in my eyes we should revert this.